### PR TITLE
Linux fixes.

### DIFF
--- a/src/QuestAPI.ts
+++ b/src/QuestAPI.ts
@@ -49,10 +49,10 @@ export class QuestAPI
         const jsonQuestAssortFiles: any[] = [];
         const jsonLocaleFiles: any[] = [];
         const jsonImageFiles: any[] = [];
-        const questFiles = fs.readdirSync(this.instanceManager.dbPath.concat(`\\Quests\\${trader}\\`));
-        const questAssortFiles = fs.readdirSync(this.instanceManager.dbPath.concat(`\\Quests\\${trader}\\questAssort`));
-        const questLocalesFiles = fs.readdirSync(this.instanceManager.dbPath.concat(`\\Quests\\${trader}\\locales`));
-        const questImageFiles = fs.readdirSync(this.instanceManager.dbPath.concat(`\\Quests\\${trader}\\images`));
+        const questFiles = fs.readdirSync(this.instanceManager.dbPath.concat(`\/Quests\/${trader}\/`));
+        const questAssortFiles = fs.readdirSync(this.instanceManager.dbPath.concat(`\/Quests\/${trader}\/questAssort`));
+        const questLocalesFiles = fs.readdirSync(this.instanceManager.dbPath.concat(`\/Quests\/${trader}\/locales`));
+        const questImageFiles = fs.readdirSync(this.instanceManager.dbPath.concat(`\/Quests\/${trader}\/images`));
 
         if (this.instanceManager.debug)
         {
@@ -69,7 +69,7 @@ export class QuestAPI
         // Load quest data from disk
         for (const file of questFiles)
         {
-            const filePath = path.join(this.instanceManager.dbPath.concat(`\\Quests\\${trader}`), file);
+            const filePath = path.join(this.instanceManager.dbPath.concat(`\/Quests\/${trader}`), file);
             const itemStats = fs.lstatSync(filePath);
             let fileContent: any;
 
@@ -97,7 +97,7 @@ export class QuestAPI
         
         for (const assort of questAssortFiles)
         {
-            const filePath = path.join(this.instanceManager.dbPath.concat(`\\Quests\\${trader}\\questAssort`), assort);
+            const filePath = path.join(this.instanceManager.dbPath.concat(`\/Quests\/${trader}\/questAssort`), assort);
             const itemStats = fs.lstatSync(filePath);
             let fileContent: any;
 
@@ -125,7 +125,7 @@ export class QuestAPI
         // Load locale data from disk
         for (const locale of questLocalesFiles)
         {
-            const filePath = path.join(this.instanceManager.dbPath.concat(`\\Quests\\${trader}\\locales`), locale);
+            const filePath = path.join(this.instanceManager.dbPath.concat(`\/Quests\/${trader}\/locales`), locale);
             const itemStats = fs.lstatSync(filePath);
             let fileContent: any;
 
@@ -154,7 +154,7 @@ export class QuestAPI
         // Load image paths from disk
         for (const image of questImageFiles)
         {
-            const filePath = path.join(this.instanceManager.dbPath.concat(`\\Quests\\${trader}\\images`), image);
+            const filePath = path.join(this.instanceManager.dbPath.concat(`\/Quests\/${trader}\/images`), image);
             const itemStats = fs.lstatSync(filePath);
 
             if (itemStats.isFile()) 


### PR DESCRIPTION
Changes any instances of `\\` to be `\/` in file paths to stop issues finding the files when used on Linux. https://github.com/EpicRangeTime/WTT-AEK-971/issues/1#issue-2813504687

Tested to be working on my personal install, dedicated server, and dedicated client running on Debian 12 and Arch Linux.